### PR TITLE
Configure ruff formatter in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ env:
   FORCE_COLOR: 1
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: chartboost/ruff-action@v1
+      with:
+          version: "0.6.5"
+          args: 'format --check'
+
   test:
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,6 @@ filterwarnings = [
     # See https://github.com/PHOTOX/promdens/issues/9
     "ignore:`trapz` is deprecated.*:DeprecationWarning:",
 ]
+
+[tool.ruff]
+line-length = 130

--- a/src/promdens/promdens.py
+++ b/src/promdens/promdens.py
@@ -19,42 +19,45 @@ from timeit import default_timer as timer
 
 import numpy as np
 
-ENERGY_UNITS = ['a.u.', 'eV', 'nm', 'cm-1']
-TDM_UNITS = ['a.u.', 'debye']
-METHODS = ['pda', 'pdaw']
-ENVELOPE_TYPES = ['gauss', 'lorentz', 'sech', 'sin', 'sin2']
-NEG_PROB_HANDLING = ['error', 'ignore', 'abs']
-FILE_TYPES = ['file']
+ENERGY_UNITS = ["a.u.", "eV", "nm", "cm-1"]
+TDM_UNITS = ["a.u.", "debye"]
+METHODS = ["pda", "pdaw"]
+ENVELOPE_TYPES = ["gauss", "lorentz", "sech", "sin", "sin2"]
+NEG_PROB_HANDLING = ["error", "ignore", "abs"]
+FILE_TYPES = ["file"]
 
 DESC = "Promoted density approach for initial conditions"
 
 
 ### functions and classes ###
 def print_header():
-    print("\n##########################################################\n"
-          f"###  {DESC}  ###\n"
-          "###                   * * * * *                        ###\n"
-          "###       version 1.0         Jiri Janos 2024          ###\n"
-          "##########################################################\n")
+    print(
+        "\n##########################################################\n"
+        f"###  {DESC}  ###\n"
+        "###                   * * * * *                        ###\n"
+        "###       version 1.0         Jiri Janos 2024          ###\n"
+        "##########################################################\n"
+    )
 
 
 def print_footer():
-    print('\nPromoted density approached calculation finished.'
-          '\n - "May the laser pulses be with you."\n')
-    print("       %.                                \n"
-          "        %.                    #%%%%%%%%  \n"
-          "         %.        %%        %%%%%%%%%%% \n"
-          "          %.    %%%%%       %%%%%%%%%%%% \n"
-          "           %  %%%%%%%%%    %%%%%%%%%%%%* \n"
-          "            %  %%%%%%%%%   %%%%%%%%%%%   \n"
-          "             %    %%%%%%%  %%%%%%%%      \n"
-          "              %%%%%%%%%%%  %%%%%%%       \n"
-          "              %%+%%%%%%%%% %%%%%%%       \n"
-          "                   %%%%%%% %%%%%%        \n"
-          "                %%%%%%%%%% %%%%%%        \n"
-          "                 %%%%%%%%%%%%%%%         \n"
-          "                %%%%%%%%%%%%%%           \n"
-          "                                           ")
+    print("\nPromoted density approached calculation finished." '\n - "May the laser pulses be with you."\n')
+    print(
+        "       %.                                \n"
+        "        %.                    #%%%%%%%%  \n"
+        "         %.        %%        %%%%%%%%%%% \n"
+        "          %.    %%%%%       %%%%%%%%%%%% \n"
+        "           %  %%%%%%%%%    %%%%%%%%%%%%* \n"
+        "            %  %%%%%%%%%   %%%%%%%%%%%   \n"
+        "             %    %%%%%%%  %%%%%%%%      \n"
+        "              %%%%%%%%%%%  %%%%%%%       \n"
+        "              %%+%%%%%%%%% %%%%%%%       \n"
+        "                   %%%%%%% %%%%%%        \n"
+        "                %%%%%%%%%% %%%%%%        \n"
+        "                 %%%%%%%%%%%%%%%         \n"
+        "                %%%%%%%%%%%%%%           \n"
+        "                                           "
+    )
 
 
 def positive_int(str_value: str) -> int:
@@ -96,34 +99,36 @@ class LaserPulse:
     tmax: float = dataclasses.field(init=False)
 
     def __str__(self):
-        return (f"Laser pulse parameters:\n"
-                f"  E(t) = {self.equation}\n"
-                f"  - envelope type = '{self.envelope_type}'\n"
-                f"  - omega = {self.omega:.6f} a.u.\n"
-                f"  - FWHM = {self.fwhm:.6f} a.u.\n"
-                f"  - t0 = {self.t0:.6f} a.u.\n"
-                f"  - chirp = {self.lchirp:.3e} a.u.")
+        return (
+            f"Laser pulse parameters:\n"
+            f"  E(t) = {self.equation}\n"
+            f"  - envelope type = '{self.envelope_type}'\n"
+            f"  - omega = {self.omega:.6f} a.u.\n"
+            f"  - FWHM = {self.fwhm:.6f} a.u.\n"
+            f"  - t0 = {self.t0:.6f} a.u.\n"
+            f"  - chirp = {self.lchirp:.3e} a.u."
+        )
 
     def __post_init__(self):
         if self.envelope_type not in ENVELOPE_TYPES:
             msg = f'Invalid envelope type "{self.envelope_type}"'
             raise ValueError(msg)
 
-        if self.envelope_type == 'gauss':
+        if self.envelope_type == "gauss":
             self.equation = "exp(-2*ln(2)*(t-t0)^2/fwhm^2)*cos((omega+chirp*t)*t)"
-            temporal_extent = 2.4*self.fwhm
-        elif self.envelope_type == 'lorentz':
+            temporal_extent = 2.4 * self.fwhm
+        elif self.envelope_type == "lorentz":
             self.equation = "(1+4/(1+sqrt(2))*(t/fwhm)^2)^-1*cos((omega+chirp*t)*t)"
-            temporal_extent = 8*self.fwhm
-        elif self.envelope_type == 'sech':
+            temporal_extent = 8 * self.fwhm
+        elif self.envelope_type == "sech":
             self.equation = "sech(2*ln(1+sqrt(2))*t/fwhm)*cos((omega+chirp*t)*t)"
-            temporal_extent = 4.4*self.fwhm
-        elif self.envelope_type == 'sin':
+            temporal_extent = 4.4 * self.fwhm
+        elif self.envelope_type == "sin":
             self.equation = "sin(pi/2*(t-t0+fwhm)/fwhm)*cos((omega+chirp*t)*t) in range [t0-fwhm,t0+fwhm]"
             temporal_extent = self.fwhm
-        elif self.envelope_type == 'sin2':
+        elif self.envelope_type == "sin2":
             self.equation = "sin(pi/2*(t-t0+T)/T)^2*cos((omega+chirp*t)*t) in range [t0-T,t0+T] where T=1.373412575*fwhm"
-            temporal_extent = 1/(2 - 4/np.pi*np.arcsin(2**(-1/4)))*self.fwhm
+            temporal_extent = 1 / (2 - 4 / np.pi * np.arcsin(2 ** (-1 / 4))) * self.fwhm
 
         self.tmin = self.t0 - temporal_extent
         self.tmax = self.t0 + temporal_extent
@@ -135,7 +140,7 @@ class LaserPulse:
         :param t: array of time values in atomic units
         :return: array of cos((w + lchirp*t)*t)
         """
-        return np.cos((self.omega + self.lchirp*t)*t)
+        return np.cos((self.omega + self.lchirp * t) * t)
 
     def calc_field_envelope(self, t: np.ndarray) -> np.ndarray:
         """
@@ -144,22 +149,22 @@ class LaserPulse:
         :param t: array of time values (a.u.)
         :return: array of envelope of the electric field
         """
-        if self.envelope_type == 'gauss':
-            return np.exp(-2*np.log(2)*(t - self.t0)**2/self.fwhm**2)
-        elif self.envelope_type == 'lorentz':
-            return (1 + 4/(1 + np.sqrt(2))*((t - self.t0)/self.fwhm)**2)**-1
-        elif self.envelope_type == 'sech':
-            return 1/np.cosh(2*np.log(1 + np.sqrt(2))*(t - self.t0)/self.fwhm)
-        elif self.envelope_type == 'sin':
+        if self.envelope_type == "gauss":
+            return np.exp(-2 * np.log(2) * (t - self.t0) ** 2 / self.fwhm**2)
+        elif self.envelope_type == "lorentz":
+            return (1 + 4 / (1 + np.sqrt(2)) * ((t - self.t0) / self.fwhm) ** 2) ** -1
+        elif self.envelope_type == "sech":
+            return 1 / np.cosh(2 * np.log(1 + np.sqrt(2)) * (t - self.t0) / self.fwhm)
+        elif self.envelope_type == "sin":
             field = np.zeros(shape=np.shape(t))
-            trange = np.logical_and(t >= self.tmin,t <= self.tmax)
-            field[trange] = np.sin(np.pi/2*(t[trange] - self.t0 + self.fwhm)/self.fwhm)
+            trange = np.logical_and(t >= self.tmin, t <= self.tmax)
+            field[trange] = np.sin(np.pi / 2 * (t[trange] - self.t0 + self.fwhm) / self.fwhm)
             return field
-        elif self.envelope_type == 'sin2':
-            T = 1/(2 - 4/np.pi*np.arcsin(2**(-1/4)))*self.fwhm
+        elif self.envelope_type == "sin2":
+            T = 1 / (2 - 4 / np.pi * np.arcsin(2 ** (-1 / 4))) * self.fwhm
             field = np.zeros(shape=np.shape(t))
-            trange = np.logical_and(t >= self.tmin,t <= self.tmax)
-            field[trange] = np.sin(np.pi/2*(t[trange] - self.t0 + T)/T)**2
+            trange = np.logical_and(t >= self.tmin, t <= self.tmax)
+            field[trange] = np.sin(np.pi / 2 * (t[trange] - self.t0 + T) / T) ** 2
             return field
 
 
@@ -185,7 +190,7 @@ class InitialConditions:
     debtoau = 0.393456
     autocm = 8.478354e-30  # dipole moment conversion
 
-    def __init__(self, nsamples=0, nstates=1, input_type='file'):
+    def __init__(self, nsamples=0, nstates=1, input_type="file"):
         """
         Initialization of the class.
         :param nsamples: number of inputed samples (position-momentum pairs), if set 0 then maximum number provided will be taken
@@ -217,9 +222,11 @@ class InitialConditions:
             print(f"\nERROR: Unexpected error: {err}, type: {type(err)}")
             exit(1)
 
-        if np.shape(input)[0] < self.nstates*2 + 1:  # check enough columns provided in the file for required nstates
-            print(f"\nERROR: Not enough columns provided in the input file '{fname}'! "
-                  f"\nExpected {self.nstates*2 + 1} columns for {self.nstates} excited states.")
+        if np.shape(input)[0] < self.nstates * 2 + 1:  # check enough columns provided in the file for required nstates
+            print(
+                f"\nERROR: Not enough columns provided in the input file '{fname}'! "
+                f"\nExpected {self.nstates*2 + 1} columns for {self.nstates} excited states."
+            )
             exit(1)
 
         if self.nsamples == 0:  # use all samples loaded if user input nsamples is 0
@@ -229,9 +236,9 @@ class InitialConditions:
             print(f"  - Number of samples loaded from the input file {np.shape(input)[1]} instead of requested {self.nsamples}")
             self.nsamples = np.shape(input)[1]
 
-        self.traj_index = np.array(input[0, :self.nsamples], dtype=int)  # saving indexes of trajectories
-        self.de = input[1:self.nstates*2:2, :self.nsamples]  # saving excitation energies
-        self.tdm = input[2:self.nstates*2 + 1:2, :self.nsamples]  # saving transition dipole moments
+        self.traj_index = np.array(input[0, : self.nsamples], dtype=int)  # saving indexes of trajectories
+        self.de = input[1 : self.nstates * 2 : 2, : self.nsamples]  # saving excitation energies
+        self.tdm = input[2 : self.nstates * 2 + 1 : 2, : self.nsamples]  # saving transition dipole moments
 
         # converting energy and tdm units to a.u.
         self.convert_units(energy_unit=energy_unit, tdm_unit=tdm_unit)
@@ -243,20 +250,20 @@ class InitialConditions:
         :param tdm_unit: unit of transition dipole moments on the input
         """
 
-        if not (energy_unit == 'a.u.' and tdm_unit == 'a.u.'):
+        if not (energy_unit == "a.u." and tdm_unit == "a.u."):
             print("* Converting units.")
 
-        if energy_unit == 'eV':
+        if energy_unit == "eV":
             self.de *= self.evtoau
             print("  - 'eV' -> 'a.u.'")
-        elif energy_unit == 'nm':
+        elif energy_unit == "nm":
             self.de *= self.nmtoau
             print("  - 'nm' -> 'a.u.'")
-        elif energy_unit == 'cm-1':
+        elif energy_unit == "cm-1":
             self.de *= self.cm1toau
             print("  - 'cm-1' -> 'a.u.'")
 
-        if tdm_unit == 'debye':
+        if tdm_unit == "debye":
             self.tdm *= self.debtoau
             print("  - 'debye' -> 'a.u.'")
 
@@ -275,29 +282,29 @@ class InitialConditions:
             :param h: width of the Gaussian (a.u.)
             :return: Gaussian as a function of energy with intensity proportional to TDM
             """
-            return de*tdm**2*np.exp(-(e - de)**2/2/h**2)
+            return de * tdm**2 * np.exp(-((e - de) ** 2) / 2 / h**2)
 
         print("* Calculating spectrum with the Nuclear Ensemble Approach.")
 
         # calculating coefficient for intensity of the spectrum
         eps0 = 8.854188e-12
-        hbar = 6.626070e-34/(2*np.pi)
+        hbar = 6.626070e-34 / (2 * np.pi)
         c = 299792458
-        int_coeff = np.pi*self.autocm**2*1e4/(3*hbar*eps0*c)/self.nsamples/np.sqrt(2*np.pi)
+        int_coeff = np.pi * self.autocm**2 * 1e4 / (3 * hbar * eps0 * c) / self.nsamples / np.sqrt(2 * np.pi)
 
         # width for the Gaussians set by Silverman’s rule of thumb: https://doi.org/10.1039/C8CP00199E
         emin, emax = np.min(self.de), np.max(self.de)
         self.spectrum = np.zeros(shape=(self.nstates + 2, 10000), dtype=float)
-        h = (4/3/self.nsamples)**0.2*np.std(self.de)  # width h for all data to get energy range of the spectrum
-        self.spectrum[0] = np.linspace(emin - 2*h, emax + 2*h, np.shape(self.spectrum)[1])
+        h = (4 / 3 / self.nsamples) ** 0.2 * np.std(self.de)  # width h for all data to get energy range of the spectrum
+        self.spectrum[0] = np.linspace(emin - 2 * h, emax + 2 * h, np.shape(self.spectrum)[1])
 
         for state in range(self.nstates):
-            h = (4/3/self.nsamples)**0.2*np.std(self.de[state])  # width h for individual states
+            h = (4 / 3 / self.nsamples) ** 0.2 * np.std(self.de[state])  # width h for individual states
 
             for ic in range(self.nsamples):
                 self.spectrum[state + 1] += gauss(self.spectrum[0], self.de[state, ic], self.tdm[state, ic], h)
 
-            self.spectrum[state + 1] *= int_coeff/h
+            self.spectrum[state + 1] *= int_coeff / h
 
         # calculating total spectrum (summing over all states)
         self.spectrum[-1] = np.sum(self.spectrum[1:-1], axis=0)
@@ -319,17 +326,19 @@ class InitialConditions:
         self.tmax = self.pulse.tmax
 
         # calculating the field
-        self.field_t = np.arange(self.tmin, self.tmax, 2*np.pi/self.field_omega/50)  # time array for the field in a.u.
+        self.field_t = np.arange(self.tmin, self.tmax, 2 * np.pi / self.field_omega / 50)  # time array for the field in a.u.
         self.field_envelope = self.pulse.calc_field_envelope(self.field_t)
-        self.field = self.field_envelope*self.pulse.field_cos(self.field_t)
+        self.field = self.field_envelope * self.pulse.field_cos(self.field_t)
 
         # calculating the FT of the field (pulse spectrum)
-        dt = 2*np.pi/self.field_omega/50
-        t_ft = np.arange(self.tmin - 20*self.field_fwhm, self.tmax + 20*self.field_fwhm, dt)  # setting up new time array with denser points for FT
-        field = self.pulse.calc_field_envelope(t_ft)*self.pulse.field_cos(t_ft)
+        dt = 2 * np.pi / self.field_omega / 50
+        t_ft = np.arange(
+            self.tmin - 20 * self.field_fwhm, self.tmax + 20 * self.field_fwhm, dt
+        )  # setting up new time array with denser points for FT
+        field = self.pulse.calc_field_envelope(t_ft) * self.pulse.field_cos(t_ft)
         self.field_ft = np.abs(np.fft.rfft(field))  # FT
         self.field_ft /= np.max(self.field_ft)  # normalizing to have maximum at 0
-        self.field_ft_omega = 2*np.pi*np.fft.rfftfreq(len(t_ft), dt)
+        self.field_ft_omega = 2 * np.pi * np.fft.rfftfreq(len(t_ft), dt)
 
         # TODO: Move to function `is_maxwell_fulfilled()`
         # checking the pulse fulfils Maxwell's equations (integral from -infinity to infinity of E(t) = E(w=0) 0)
@@ -339,9 +348,11 @@ class InitialConditions:
             integral = self.field_ft[self.field_ft_omega == 0]
 
         if integral > 0.01:  # empirical threshold which considers the spectrum has maximum equal to 1
-            print("  - WARNING: Pulse is too short and integral of E(t) is not equal to 0 - Maxwell's equations are "
-                  "not fulfilled. This means that representation of pulse as envelope times cos(wt) is not physical. "
-                  "See the original reference for more details.")
+            print(
+                "  - WARNING: Pulse is too short and integral of E(t) is not equal to 0 - Maxwell's equations are "
+                "not fulfilled. This means that representation of pulse as envelope times cos(wt) is not physical. "
+                "See the original reference for more details."
+            )
             self.maxwell_fulfilled = False
         else:
             print("  - Integral of E(t) from -infinity to infinity is equal to 0 - pulse is physically realizable.")
@@ -357,38 +368,40 @@ class InitialConditions:
         :return: Wigner pulse transform
         """
         # setting an adaptive integration step according to the frequency of the integrand oscillations (de - omega)
-        loc_omega = self.field_omega + 2*self.field_lchirp*tprime
+        loc_omega = self.field_omega + 2 * self.field_lchirp * tprime
         if de != loc_omega:
-            T = 2*np.pi/(np.min([np.abs(de - loc_omega), loc_omega]))
+            T = 2 * np.pi / (np.min([np.abs(de - loc_omega), loc_omega]))
         else:  # in case they are equal, there are no phase oscillations and we integrate only the envelope intensity
-            T = 2*np.pi/loc_omega
-        ds = np.min([T/50, self.field_fwhm/500])  # time step for integration
+            T = 2 * np.pi / loc_omega
+        ds = np.min([T / 50, self.field_fwhm / 500])  # time step for integration
 
         # integration ranges for different pulse envelopes
         # ideally, we would integrate from -infinity to infinity, yet this is not very computationally efficient
         # empirically, it was found out that efficient integration varies for different pulses
         # analytic formulas should be implemented in the future to avoid that
-        if self.field_envelope_type == 'gauss':
+        if self.field_envelope_type == "gauss":
             factor = 7.5
-        elif self.field_envelope_type == 'lorentz':
+        elif self.field_envelope_type == "lorentz":
             factor = 50
-        elif self.field_envelope_type == 'sech':
+        elif self.field_envelope_type == "sech":
             factor = 20
-        elif self.field_envelope_type == 'sin':
+        elif self.field_envelope_type == "sin":
             factor = 3
-        elif self.field_envelope_type == 'sin2':
+        elif self.field_envelope_type == "sin2":
             factor = 4
 
         # instead of calculating the complex integral int_{-inf}^{inf}[E(t+s/2)E(t-s/2)exp(i(w-de)s)]ds we use the
         # properties of even and odd fucntions and calculate 2*int_{0}^{inf}[E(t+s/2)E(t-s/2)cos((w-de)s)]ds
-        s = np.arange(0, factor*self.field_fwhm, step=ds)
-        cos = np.cos((de/self.hbar - loc_omega)*s)
-        integral = np.trapz(x=s, y=cos*self.pulse.calc_field_envelope(tprime + s/2)*self.pulse.calc_field_envelope(tprime - s/2))
+        s = np.arange(0, factor * self.field_fwhm, step=ds)
+        cos = np.cos((de / self.hbar - loc_omega) * s)
+        integral = np.trapz(
+            x=s, y=cos * self.pulse.calc_field_envelope(tprime + s / 2) * self.pulse.calc_field_envelope(tprime - s / 2)
+        )
         # the factor 2 was omitted as the Wigner transform is always normalized
 
         return integral
 
-    def sample_initial_conditions(self, nsamples_ic: int, neg_handling: str, preselect: bool, seed=None, output_fname='pda.dat'):
+    def sample_initial_conditions(self, nsamples_ic: int, neg_handling: str, preselect: bool, seed=None, output_fname="pda.dat"):
         """
         Sample time-dependent initial conditions using the Promoted Density Approach.
         :param nsamples_ic: number of initial conditions to be sampled
@@ -397,24 +410,28 @@ class InitialConditions:
 
         print(f"* Sampling {nsamples_ic:d} initial conditions considering the laser pulse.")
 
-        def progress(percent, width, n, str=''):
+        def progress(percent, width, n, str=""):
             """Function to print progress of calculation."""
-            left = width*percent//n
+            left = width * percent // n
             right = width - left
-            print(f'\r{str}[', '#'*left, ' '*right, '] %d'%(percent*100/n) + '%', sep='', end='', flush=True)
+            print(f"\r{str}[", "#" * left, " " * right, "] %d" % (percent * 100 / n) + "%", sep="", end="", flush=True)
 
         # variable storing initial conditions
         samples = np.zeros((5, nsamples_ic))  # index, excitation time, initial excited state, de, tdm
 
         # setting maximum random number generated during sampling
-        rnd_max = (np.max(self.tdm**2)*self.pulse_wigner(self.field_t0, de=self.field_omega + self.field_lchirp*self.field_t0)*1.01)
+        rnd_max = (
+            np.max(self.tdm**2) * self.pulse_wigner(self.field_t0, de=self.field_omega + self.field_lchirp * self.field_t0) * 1.01
+        )
 
         # preselection of initial conditions based on pulse spectrum in order to avoid long calculation of the Wigner
         # distribution for samples far from resonance (the more out of resonance with the field, the more the integrand
         # oscillates and the finer grid is needed, although the result is zero; will be resolved with analytic integrals)
         # True - sample will be skipped; False - sample will be considered for sampling of initial conditions
         if preselect:
-            preselected = np.interp(x=self.de, xp=self.field_ft_omega, fp=self.field_ft) < 1e-6  # considering field_ft is normalized and positive
+            preselected = (
+                np.interp(x=self.de, xp=self.field_ft_omega, fp=self.field_ft) < 1e-6
+            )  # considering field_ft is normalized and positive
             print(f"  - Discarding {np.sum(preselected):d} samples that are not within the pulse spectrum [sigma(dE) < 10^-6].")
         else:
             preselected = np.zeros(shape=(self.nstates, self.nsamples), dtype=bool)
@@ -439,23 +456,27 @@ class InitialConditions:
             rnd = rng.uniform(low=0, high=rnd_max)  # random number to be compared with Wig. dist.
 
             # excitation probability
-            prob = self.tdm[rnd_state, rnd_index]**2*self.pulse_wigner(rnd_time, self.de[rnd_state, rnd_index])
+            prob = self.tdm[rnd_state, rnd_index] ** 2 * self.pulse_wigner(rnd_time, self.de[rnd_state, rnd_index])
 
             # check and handle negative probabilities
-            if prob < -1e-12*rnd_max:  # check negative value bigger than integration precision
-                if neg_handling == 'error':
-                    print(f"\nERROR: Negative probability ({prob/rnd_max*100:.1e}%) encountered! Check flag 'neg_handling' "
-                          f"for more option how to handle negative probabilities. See also manual and ref XXX for more "
-                          f"information.\n")
+            if prob < -1e-12 * rnd_max:  # check negative value bigger than integration precision
+                if neg_handling == "error":
+                    print(
+                        f"\nERROR: Negative probability ({prob/rnd_max*100:.1e}%) encountered! Check flag 'neg_handling' "
+                        f"for more option how to handle negative probabilities. See also manual and ref XXX for more "
+                        f"information.\n"
+                    )
                     exit(1)
-                elif neg_handling == 'ignore':
+                elif neg_handling == "ignore":
                     continue
-                elif neg_handling == 'abs':
+                elif neg_handling == "abs":
                     prob = np.abs(prob)
 
             if prob > rnd_max:  # check if the probability is higher than rnd_max, restart while loop
-                print(f"\n - rnd_max ({rnd_max}) is smaller than probability ({prob} for sample "
-                      f"{self.traj_index[rnd_index]} on state {rnd_state}). Increasing rnd_max and reruning.")
+                print(
+                    f"\n - rnd_max ({rnd_max}) is smaller than probability ({prob} for sample "
+                    f"{self.traj_index[rnd_index]} on state {rnd_state}). Increasing rnd_max and reruning."
+                )
                 rnd_max *= 1.2  # increase rnd_max
                 samples = np.zeros((5, nsamples_ic))
                 i = 0  # reset index
@@ -466,7 +487,7 @@ class InitialConditions:
                 samples[3, i] = self.de[rnd_state, rnd_index]
                 samples[4, i] = self.tdm[rnd_state, rnd_index]
                 i += 1
-                progress(i, 50, nsamples_ic, str='  - Sampling progress: ')
+                progress(i, 50, nsamples_ic, str="  - Sampling progress: ")
 
         # saving samples within the object
         samples = samples[:, samples[0].argsort()]  # sorting according to sample index
@@ -482,26 +503,38 @@ class InitialConditions:
 
         # print indexes of trajectories that must be propagated
         if self.nstates == 1:
-            print(f"  - Selected {unique_states[0]} unique ICs from {self.nsamples} provided. Unique ICs to be "
-                  f"propagated:\n   ", *np.array(unique[0], dtype=str))
+            print(
+                f"  - Selected {unique_states[0]} unique ICs from {self.nsamples} provided. Unique ICs to be "
+                f"propagated:\n   ",
+                *np.array(unique[0], dtype=str),
+            )
         else:
-            print(f"  - Selected {np.sum(unique_states)} unique ICs over {self.nstates} state from {self.nsamples} "
-                  f"positions and velocities provided.")
+            print(
+                f"  - Selected {np.sum(unique_states)} unique ICs over {self.nstates} state from {self.nsamples} "
+                f"positions and velocities provided."
+            )
             for state in range(self.nstates):
                 if unique_states[state] == 0:
                     continue
-                print(f"  - State {state + 1} - {unique_states[state]} unique ICs to be propagated: \n   ", *np.array(unique[state], dtype=str))
+                print(
+                    f"  - State {state + 1} - {unique_states[state]} unique ICs to be propagated: \n   ",
+                    *np.array(unique[state], dtype=str),
+                )
 
         # save the selected samples
-        np.savetxt(output_fname, samples.T, fmt=['%8d', '%18.8f', '%12d', '%16.8f', '%16.8f'],
-                   header=f"Sampling: number of ICs = {nsamples_ic:d}, number of unique ICs = {np.sum(unique_states):d}\n"
-                          f"Field parameters: omega = {self.field_omega:.5e} a.u., "
-                          f"linear_chirp = {self.field_lchirp:.5e} a.u., fwhm = {self.field_fwhm/self.fstoau:.3f} fs, "
-                          f"t0 = {self.field_t0/self.fstoau:.3f} fs, envelope type = '{self.field_envelope_type}'\n"
-                          f"index        exc. time (a.u.)   el. state     dE (a.u.)       |tdm| (a.u.)")
+        np.savetxt(
+            output_fname,
+            samples.T,
+            fmt=["%8d", "%18.8f", "%12d", "%16.8f", "%16.8f"],
+            header=f"Sampling: number of ICs = {nsamples_ic:d}, number of unique ICs = {np.sum(unique_states):d}\n"
+            f"Field parameters: omega = {self.field_omega:.5e} a.u., "
+            f"linear_chirp = {self.field_lchirp:.5e} a.u., fwhm = {self.field_fwhm/self.fstoau:.3f} fs, "
+            f"t0 = {self.field_t0/self.fstoau:.3f} fs, envelope type = '{self.field_envelope_type}'\n"
+            f"index        exc. time (a.u.)   el. state     dE (a.u.)       |tdm| (a.u.)",
+        )
         print("  - Output saved to file 'pda.dat'.")
 
-    def windowing(self, output_fname='pdaw.dat'):
+    def windowing(self, output_fname="pdaw.dat"):
         """
         Performs Promoted Density Approach for Windowing (PDAW). The function calculates normalized weights and outputs
         the convolution functions I(t).
@@ -512,18 +545,20 @@ class InitialConditions:
         print("* Generating weights and convolution for windowing.")
 
         # determine and print convolution function
-        if self.field_envelope_type == 'gauss':
+        if self.field_envelope_type == "gauss":
             self.conv = "I(t) = exp(-4*ln(2)*(t-t0)^2/fwhm^2)"
-        elif self.field_envelope_type == 'lorentz':
+        elif self.field_envelope_type == "lorentz":
             self.conv = "I(t) = (1+4/(1+sqrt(2))*(t/fwhm)^2)^-2"
-        elif self.field_envelope_type == 'sech':
+        elif self.field_envelope_type == "sech":
             self.conv = "I(t) = sech(2*ln(1+sqrt(2))*t/fwhm)^2"
-        elif self.field_envelope_type == 'sin':
+        elif self.field_envelope_type == "sin":
             self.conv = "I(t) = sin(pi/2*(t-t0+fwhm)/fwhm)^2 in range [t0-fwhm,t0+fwhm]"
-        elif self.field_envelope_type == 'sin2':
+        elif self.field_envelope_type == "sin2":
             self.conv = "I(t) = sin(pi/2*(t-t0+T)/T)^4 in range [t0-T,t0+T] where T=1.373412575*fwhm"
-        print(f"  - Convolution: {self.conv}\n  - Parameters:  fwhm = {self.field_fwhm/self.fstoau:.3f} fs, "
-              f"t0 = {self.field_t0/self.fstoau:.3f} fs)")
+        print(
+            f"  - Convolution: {self.conv}\n  - Parameters:  fwhm = {self.field_fwhm/self.fstoau:.3f} fs, "
+            f"t0 = {self.field_t0/self.fstoau:.3f} fs)"
+        )
 
         print("  - Calculating normalized weights:")
         # creating a field for weights
@@ -531,14 +566,18 @@ class InitialConditions:
 
         # generating weights for all states and samples
         for state in range(0, self.nstates):
-            self.weights[state] = self.tdm[state]**2*np.interp(self.de[state], self.field_ft_omega, self.field_ft)**2
+            self.weights[state] = self.tdm[state] ** 2 * np.interp(self.de[state], self.field_ft_omega, self.field_ft) ** 2
 
             # analysis
-            sorted = np.sort(self.weights[state, :]/np.sum(self.weights[state, :]))[::-1]  # sorting from the largest weight to smallest
-            print(f"    > State {state + 1} -  analysis of normalized weights (weights/sum of weights on state {state + 1}):\n"
-                  f"      - Largest weight: {np.max(self.weights[state, :]):.3e}\n"
-                  f"      - Number of ICs making up 90% of S{state + 1} weights: {np.sum(np.cumsum(sorted) < 0.9) + 1:d}\n"
-                  f"      - Number of ICs with weights bigger than 0.001: {np.sum(self.weights[state, :] > 0.001):d}")
+            sorted = np.sort(self.weights[state, :] / np.sum(self.weights[state, :]))[
+                ::-1
+            ]  # sorting from the largest weight to smallest
+            print(
+                f"    > State {state + 1} -  analysis of normalized weights (weights/sum of weights on state {state + 1}):\n"
+                f"      - Largest weight: {np.max(self.weights[state, :]):.3e}\n"
+                f"      - Number of ICs making up 90% of S{state + 1} weights: {np.sum(np.cumsum(sorted) < 0.9) + 1:d}\n"
+                f"      - Number of ICs with weights bigger than 0.001: {np.sum(self.weights[state, :] > 0.001):d}"
+            )
 
         # normalization of weights at given state
         self.weights /= np.sum(self.weights)
@@ -548,10 +587,14 @@ class InitialConditions:
         arr_print[0, :] = self.traj_index
         arr_print[1:, :] = self.weights
 
-        np.savetxt(output_fname, arr_print.T, fmt=['%8d'] + ['%16.5e']*self.nstates,
-                   header=f"Convolution: '{self.conv}'\nParameters:  fwhm = {self.field_fwhm/self.fstoau:.3f} fs, "
-                          f"t0 = {self.field_t0/self.fstoau:.3f} fs\n"
-                          f"index        " + str(' '*8).join([f"weight S{s + 1:d}" for s in range(self.nstates)]))
+        np.savetxt(
+            output_fname,
+            arr_print.T,
+            fmt=["%8d"] + ["%16.5e"] * self.nstates,
+            header=f"Convolution: '{self.conv}'\nParameters:  fwhm = {self.field_fwhm/self.fstoau:.3f} fs, "
+            f"t0 = {self.field_t0/self.fstoau:.3f} fs\n"
+            f"index        " + str(" " * 8).join([f"weight S{s + 1:d}" for s in range(self.nstates)]),
+        )
 
         print("  - Weights saved to file 'pdaw.dat'.")
 
@@ -565,18 +608,20 @@ def plot_spectrum(ics: InitialConditions) -> None:
         colors.append(plt.cm.viridis(0.2))  # color for the total spectrum
     fig, axs = plt.subplots(1, 3, figsize=(12, 3.5))
     fig.suptitle("Characteristics of initial conditions (ICs) loaded")
-    plt.get_current_fig_manager().set_window_title('UV/vis absorption spectrum')  # modify the window name from Figure x
+    plt.get_current_fig_manager().set_window_title("UV/vis absorption spectrum")  # modify the window name from Figure x
 
     for state in range(ics.nstates):
-        axs[0].plot(ics.traj_index, ics.de[state]/ics.evtoau, color=colors[state], alpha=0.6, label=r"S$_\mathregular{%d}$"%state)
-        axs[0].scatter(ics.traj_index, ics.de[state]/ics.evtoau, color=colors[state], s=5)
+        axs[0].plot(
+            ics.traj_index, ics.de[state] / ics.evtoau, color=colors[state], alpha=0.6, label=r"S$_\mathregular{%d}$" % state
+        )
+        axs[0].scatter(ics.traj_index, ics.de[state] / ics.evtoau, color=colors[state], s=5)
     axs[0].set_xlim(np.min(ics.traj_index) - 1, np.max(ics.traj_index) + 1)
     axs[0].set_xlabel("IC index")
     axs[0].set_ylabel(r"$\Delta E$ (eV)")
     axs[0].set_title(r"Excitation energies")
     axs[0].legend(frameon=False, labelspacing=0.1)
     axs[0].minorticks_on()
-    axs[0].tick_params('both', direction='in', which='both', top=True, right=True)
+    axs[0].tick_params("both", direction="in", which="both", top=True, right=True)
 
     for state in range(ics.nstates):
         axs[1].plot(ics.traj_index, ics.tdm[state], color=colors[state], alpha=0.6)
@@ -586,26 +631,26 @@ def plot_spectrum(ics: InitialConditions) -> None:
     axs[1].set_ylabel(r"$|\mu|$ (a.u.)")
     axs[1].set_title(r"Transition dipole moments")
     axs[1].minorticks_on()
-    axs[1].tick_params('both', direction='in', which='both', top=True, right=True)
+    axs[1].tick_params("both", direction="in", which="both", top=True, right=True)
 
-    axs[2].plot(ics.spectrum[0]/ics.evtoau, ics.spectrum[-1], color=colors[-1], label='Total spectrum')
-    axs[2].fill_between(ics.spectrum[0]/ics.evtoau, ics.spectrum[-1]*0, ics.spectrum[-1], color=colors[-1], alpha=0.2)
+    axs[2].plot(ics.spectrum[0] / ics.evtoau, ics.spectrum[-1], color=colors[-1], label="Total spectrum")
+    axs[2].fill_between(ics.spectrum[0] / ics.evtoau, ics.spectrum[-1] * 0, ics.spectrum[-1], color=colors[-1], alpha=0.2)
     if ics.nstates > 1:
         for state in range(ics.nstates):
-            axs[2].plot(ics.spectrum[0]/ics.evtoau, ics.spectrum[state + 1], color=colors[state], linestyle='--')
-            axs[2].fill_between(ics.spectrum[0]/ics.evtoau, 0, ics.spectrum[state + 1], color=colors[state], alpha=0.2)
-    axs[2].set_xlim(np.min(ics.spectrum[0]/ics.evtoau), np.max(ics.spectrum[0]/ics.evtoau))
-    axs[2].set_ylim(0, np.max(ics.spectrum[-1])*1.2)
+            axs[2].plot(ics.spectrum[0] / ics.evtoau, ics.spectrum[state + 1], color=colors[state], linestyle="--")
+            axs[2].fill_between(ics.spectrum[0] / ics.evtoau, 0, ics.spectrum[state + 1], color=colors[state], alpha=0.2)
+    axs[2].set_xlim(np.min(ics.spectrum[0] / ics.evtoau), np.max(ics.spectrum[0] / ics.evtoau))
+    axs[2].set_ylim(0, np.max(ics.spectrum[-1]) * 1.2)
     axs[2].set_xlabel(r"$E$ (eV)")
     axs[2].set_ylabel(r"$\sigma$ (cm$^2\cdot$molecule$^{-1}$)")
     axs[2].set_title(r"Absorption spectrum")
     axs[2].legend(frameon=False, labelspacing=0.1)
-    axs[2].ticklabel_format(style='sci', axis='y', scilimits=(0, 0), useMathText=True)
+    axs[2].ticklabel_format(style="sci", axis="y", scilimits=(0, 0), useMathText=True)
     axs[2].minorticks_on()
-    axs[2].tick_params('both', direction='in', which='both', top=True, right=True)
+    axs[2].tick_params("both", direction="in", which="both", top=True, right=True)
 
     plt.tight_layout()
-    plt.savefig('spectrum', dpi=300)
+    plt.savefig("spectrum", dpi=300)
     plt.show(block=False)
 
 
@@ -616,39 +661,55 @@ def plot_field(ics: InitialConditions) -> None:
     colors = plt.cm.viridis([0.35, 0.6, 0.0])
     fig, axs = plt.subplots(1, 2, figsize=(8, 3.5))
     fig.suptitle("Pulse characteristics")
-    plt.get_current_fig_manager().set_window_title('Pulse characteristics')  # modify the window name from Figure x
+    plt.get_current_fig_manager().set_window_title("Pulse characteristics")  # modify the window name from Figure x
 
-    axs[0].plot(ics.field_t/ics.fstoau, ics.field, color=colors[0], linewidth=0.5, label='Field')
-    axs[0].plot(ics.field_t/ics.fstoau, ics.field_envelope, color=colors[0], alpha=0.4)
-    axs[0].plot(ics.field_t/ics.fstoau, -ics.field_envelope, color=colors[0], alpha=0.4)
-    axs[0].fill_between(ics.field_t/ics.fstoau, ics.field_envelope, -ics.field_envelope, color=colors[0], label='Envelope', alpha=0.2)
-    axs[0].set_xlim(np.min(ics.field_t/ics.fstoau), np.max(ics.field_t/ics.fstoau))
-    axs[0].set_ylim(np.min(-ics.field_envelope)*1.2, np.max(ics.field_envelope)*1.2)
+    axs[0].plot(ics.field_t / ics.fstoau, ics.field, color=colors[0], linewidth=0.5, label="Field")
+    axs[0].plot(ics.field_t / ics.fstoau, ics.field_envelope, color=colors[0], alpha=0.4)
+    axs[0].plot(ics.field_t / ics.fstoau, -ics.field_envelope, color=colors[0], alpha=0.4)
+    axs[0].fill_between(
+        ics.field_t / ics.fstoau, ics.field_envelope, -ics.field_envelope, color=colors[0], label="Envelope", alpha=0.2
+    )
+    axs[0].set_xlim(np.min(ics.field_t / ics.fstoau), np.max(ics.field_t / ics.fstoau))
+    axs[0].set_ylim(np.min(-ics.field_envelope) * 1.2, np.max(ics.field_envelope) * 1.2)
     axs[0].set_xlabel(r"Time (fs)")
     axs[0].set_ylabel(r"$\vec{E}$")
     axs[0].set_title(r"Laser pulse field")
-    axs[0].legend(frameon=False, labelspacing=0.1, loc='upper left')
+    axs[0].legend(frameon=False, labelspacing=0.1, loc="upper left")
     axs[0].minorticks_on()
-    axs[0].tick_params('both', direction='in', which='both', top=True, right=True)
+    axs[0].tick_params("both", direction="in", which="both", top=True, right=True)
 
     for state in range(ics.nstates):
-        axs[1].plot(ics.spectrum[0]/ics.evtoau, ics.spectrum[state + 1]/np.max(ics.spectrum[-1]), color=colors[-1], linestyle='--', linewidth=1,
-                    alpha=0.5)
-    axs[1].plot(ics.spectrum[0]/ics.evtoau, ics.spectrum[-1]/np.max(ics.spectrum[-1]), color=colors[1], label='Absorption spectrum')
-    axs[1].fill_between(ics.spectrum[0]/ics.evtoau, ics.spectrum[-1]*0, ics.spectrum[-1]/np.max(ics.spectrum[-1]), color=colors[1], alpha=0.2)
-    axs[1].plot(ics.field_ft_omega/ics.evtoau, ics.field_ft, color=colors[0], label='Pulse spectrum')
-    axs[1].fill_between(ics.field_ft_omega/ics.evtoau, ics.field_ft*0, ics.field_ft, color=colors[0], alpha=0.2)
-    axs[1].set_xlim(np.min(ics.spectrum[0]/ics.evtoau), np.max(ics.spectrum[0]/ics.evtoau))
+        axs[1].plot(
+            ics.spectrum[0] / ics.evtoau,
+            ics.spectrum[state + 1] / np.max(ics.spectrum[-1]),
+            color=colors[-1],
+            linestyle="--",
+            linewidth=1,
+            alpha=0.5,
+        )
+    axs[1].plot(
+        ics.spectrum[0] / ics.evtoau, ics.spectrum[-1] / np.max(ics.spectrum[-1]), color=colors[1], label="Absorption spectrum"
+    )
+    axs[1].fill_between(
+        ics.spectrum[0] / ics.evtoau,
+        ics.spectrum[-1] * 0,
+        ics.spectrum[-1] / np.max(ics.spectrum[-1]),
+        color=colors[1],
+        alpha=0.2,
+    )
+    axs[1].plot(ics.field_ft_omega / ics.evtoau, ics.field_ft, color=colors[0], label="Pulse spectrum")
+    axs[1].fill_between(ics.field_ft_omega / ics.evtoau, ics.field_ft * 0, ics.field_ft, color=colors[0], alpha=0.2)
+    axs[1].set_xlim(np.min(ics.spectrum[0] / ics.evtoau), np.max(ics.spectrum[0] / ics.evtoau))
     axs[1].set_ylim(0, 1.2)
     axs[1].set_xlabel(r"$E$ (eV)")
     axs[1].set_ylabel(r"$\epsilon$")
     axs[1].set_title(r"Pulse spectrum")
     axs[1].legend(frameon=False, labelspacing=0.1)
     axs[1].minorticks_on()
-    axs[1].tick_params('both', direction='in', which='both', top=True, right=True)
+    axs[1].tick_params("both", direction="in", which="both", top=True, right=True)
 
     plt.tight_layout()
-    plt.savefig('field', dpi=300)
+    plt.savefig("field", dpi=300)
     plt.show(block=False)
 
     # In case the pulse does not fulfil Maxwell's equations, plot the whole pulse spectrum and explain.
@@ -656,23 +717,25 @@ def plot_field(ics: InitialConditions) -> None:
         print("  - Plotting Maxwell eq. violation (pulse spectrum at 0 frequency)")
         fig, axs = plt.subplots(1, 1, figsize=(4, 3.5))
         fig.suptitle("Pulse spectrum nonzero at zero frequency!")
-        plt.get_current_fig_manager().set_window_title('Maxwell eq. violation')  # modify the window name from Figure x
+        plt.get_current_fig_manager().set_window_title("Maxwell eq. violation")  # modify the window name from Figure x
 
-        axs.plot(ics.field_ft_omega/ics.evtoau, ics.field_ft, color=colors[0], label='Pulse spectrum')
-        axs.fill_between(ics.field_ft_omega/ics.evtoau, ics.field_ft*0, ics.field_ft, color=colors[0], alpha=0.2)
-        axs.axvline(0, color='black', lw=0.5)
-        axs.scatter(ics.field_ft_omega[0]/ics.evtoau, ics.field_ft[0], color='black')
-        axs.set_xlim(-0.1, ics.field_ft_omega[np.argmax(ics.field_ft)*2]/ics.evtoau)
+        axs.plot(ics.field_ft_omega / ics.evtoau, ics.field_ft, color=colors[0], label="Pulse spectrum")
+        axs.fill_between(ics.field_ft_omega / ics.evtoau, ics.field_ft * 0, ics.field_ft, color=colors[0], alpha=0.2)
+        axs.axvline(0, color="black", lw=0.5)
+        axs.scatter(ics.field_ft_omega[0] / ics.evtoau, ics.field_ft[0], color="black")
+        axs.set_xlim(-0.1, ics.field_ft_omega[np.argmax(ics.field_ft) * 2] / ics.evtoau)
         axs.set_ylim(0, 1.2)
         axs.set_xlabel(r"$E$ (eV)")
         axs.set_ylabel(r"Pulse spectrum")
-        axs.set_title(r"$\int_{-\infty}^\infty \vec{E}(t) \mathregular{d}t = \mathcal{F}[\vec{E}(t)]|_{\omega=0} \neq 0$"
-                      "\nViolation of Maxwell's equations!")
+        axs.set_title(
+            r"$\int_{-\infty}^\infty \vec{E}(t) \mathregular{d}t = \mathcal{F}[\vec{E}(t)]|_{\omega=0} \neq 0$"
+            "\nViolation of Maxwell's equations!"
+        )
         axs.minorticks_on()
-        axs.tick_params('both', direction='in', which='both', top=True, right=True)
+        axs.tick_params("both", direction="in", which="both", top=True, right=True)
 
         plt.tight_layout()
-        plt.savefig('field_maxwell_violation', dpi=300)
+        plt.savefig("field_maxwell_violation", dpi=300)
         plt.show(block=False)
 
 
@@ -683,7 +746,7 @@ def plot_pda(ics: InitialConditions) -> None:
     colors = plt.cm.viridis([0.35, 0.6])
     fig = plt.figure(figsize=(6, 6))
     fig.suptitle("Excitations in time")
-    plt.get_current_fig_manager().set_window_title('PDA initial conditions')  # modify the window name from Figure x
+    plt.get_current_fig_manager().set_window_title("PDA initial conditions")  # modify the window name from Figure x
 
     # setting the other plots around the main plot
     left, width = 0.1, 0.65
@@ -694,39 +757,59 @@ def plot_pda(ics: InitialConditions) -> None:
     rect_histy = [left + width + spacing, bottom, 0.2, height]
     axs = fig.add_axes(rect_scatter)
 
-    emin, emax = np.min(ics.spectrum[0]/ics.evtoau), np.max(ics.spectrum[0]/ics.evtoau)
-    tmin, tmax = np.min(ics.field_t/ics.fstoau), np.max(ics.field_t/ics.fstoau)
+    emin, emax = np.min(ics.spectrum[0] / ics.evtoau), np.max(ics.spectrum[0] / ics.evtoau)
+    tmin, tmax = np.min(ics.field_t / ics.fstoau), np.max(ics.field_t / ics.fstoau)
 
-    axs.hist2d(ics.ics[3]/ics.evtoau, ics.ics[1]/ics.fstoau, range=[[emin, emax], [tmin, tmax]], bins=(100, 100), cmap=plt.cm.viridis, density=True, )
+    axs.hist2d(
+        ics.ics[3] / ics.evtoau,
+        ics.ics[1] / ics.fstoau,
+        range=[[emin, emax], [tmin, tmax]],
+        bins=(100, 100),
+        cmap=plt.cm.viridis,
+        density=True,
+    )
     if ics.field_lchirp != 0:
-        axs.plot((ics.field_omega + 2*ics.field_lchirp*ics.field_t)/ics.evtoau, ics.field_t/ics.fstoau, color="white", linestyle="--",
-                 label=r"$\omega(t)$", )
+        axs.plot(
+            (ics.field_omega + 2 * ics.field_lchirp * ics.field_t) / ics.evtoau,
+            ics.field_t / ics.fstoau,
+            color="white",
+            linestyle="--",
+            label=r"$\omega(t)$",
+        )
         axs.legend(frameon=True, framealpha=0.4, labelspacing=0.1)
 
     ax_histy = fig.add_axes(rect_histy, sharey=axs)
-    ax_histy.plot(ics.field_envelope**2, ics.field_t/ics.fstoau, color=colors[0], label="Pulse \nintensity")
-    ax_histy.fill_betweenx(ics.field_t/ics.fstoau, ics.field_envelope**2, 0, color=colors[0], alpha=0.2)
+    ax_histy.plot(ics.field_envelope**2, ics.field_t / ics.fstoau, color=colors[0], label="Pulse \nintensity")
+    ax_histy.fill_betweenx(ics.field_t / ics.fstoau, ics.field_envelope**2, 0, color=colors[0], alpha=0.2)
     ax_histy.set_xlim(0, 1.2)
-    ax_histy.legend(frameon=True, framealpha=0.9, labelspacing=0.1, edgecolor='white')
+    ax_histy.legend(frameon=True, framealpha=0.9, labelspacing=0.1, edgecolor="white")
 
     ax_histx = fig.add_axes(rect_histx, sharex=axs)
-    ax_histx.plot(ics.spectrum[0]/ics.evtoau, ics.spectrum[-1]/np.max(ics.spectrum[-1]), color=colors[1], label='Absorption spectrum')
-    ax_histx.fill_between(ics.spectrum[0]/ics.evtoau, ics.spectrum[-1]*0, ics.spectrum[-1]/np.max(ics.spectrum[-1]), color=colors[1], alpha=0.2)
-    ax_histx.plot(ics.field_ft_omega/ics.evtoau, ics.field_ft**2, color=colors[0], label='Pulse spec. intensity')
-    ax_histx.fill_between(ics.field_ft_omega/ics.evtoau, ics.field_ft*0, ics.field_ft**2, color=colors[0], alpha=0.2)
+    ax_histx.plot(
+        ics.spectrum[0] / ics.evtoau, ics.spectrum[-1] / np.max(ics.spectrum[-1]), color=colors[1], label="Absorption spectrum"
+    )
+    ax_histx.fill_between(
+        ics.spectrum[0] / ics.evtoau,
+        ics.spectrum[-1] * 0,
+        ics.spectrum[-1] / np.max(ics.spectrum[-1]),
+        color=colors[1],
+        alpha=0.2,
+    )
+    ax_histx.plot(ics.field_ft_omega / ics.evtoau, ics.field_ft**2, color=colors[0], label="Pulse spec. intensity")
+    ax_histx.fill_between(ics.field_ft_omega / ics.evtoau, ics.field_ft * 0, ics.field_ft**2, color=colors[0], alpha=0.2)
     ax_histx.set_ylim(0, 1.2)
     ax_histx.legend(frameon=False, labelspacing=0.1)
 
-    ax_histx.tick_params("both", which='both', direction='in', labelbottom=False)
-    ax_histy.tick_params("both", which='both', direction='in', labelleft=False)
+    ax_histx.tick_params("both", which="both", direction="in", labelbottom=False)
+    ax_histy.tick_params("both", which="both", direction="in", labelleft=False)
     ax_histy.set_xticks([])
     ax_histx.set_yticks([])
     axs.set_xlabel(r"$\Delta E$ (eV)")
     axs.set_ylabel(r"Time (fs)")
     axs.minorticks_on()
-    axs.tick_params("both", which='both', direction='in', top=True, right=True, color='white')
+    axs.tick_params("both", which="both", direction="in", top=True, right=True, color="white")
 
-    plt.savefig('pda', dpi=300)
+    plt.savefig("pda", dpi=300)
     plt.show()
 
 
@@ -739,71 +822,133 @@ def plot_pdaw(ics: InitialConditions) -> None:
         colors.append(plt.cm.viridis(0.2))  # color for the total spectrum
     fig, axs = plt.subplots(1, 1, figsize=(4, 3.5))
     fig.suptitle("Selected initial conditions and their weights")
-    plt.get_current_fig_manager().set_window_title('PDAW weights')  # modify the window name from Figure x
+    plt.get_current_fig_manager().set_window_title("PDAW weights")  # modify the window name from Figure x
 
-    axs.plot(ics.spectrum[0]/ics.evtoau, ics.spectrum[-1]/np.max(ics.spectrum[-1]), color=colors[-1], label='Absorption spectrum')
-    axs.fill_between(ics.spectrum[0]/ics.evtoau, ics.spectrum[-1]*0, ics.spectrum[-1]/np.max(ics.spectrum[-1]), color=colors[-1], alpha=0.2)
+    axs.plot(
+        ics.spectrum[0] / ics.evtoau, ics.spectrum[-1] / np.max(ics.spectrum[-1]), color=colors[-1], label="Absorption spectrum"
+    )
+    axs.fill_between(
+        ics.spectrum[0] / ics.evtoau,
+        ics.spectrum[-1] * 0,
+        ics.spectrum[-1] / np.max(ics.spectrum[-1]),
+        color=colors[-1],
+        alpha=0.2,
+    )
 
     maxw = np.max(ics.weights)
     if ics.nstates > 1:
         for state in range(ics.nstates):
             # plotting spectrum
-            axs.plot(ics.spectrum[0]/ics.evtoau, ics.spectrum[state + 1]/np.max(ics.spectrum[-1]), color=colors[state], linestyle='--')
-            axs.fill_between(ics.spectrum[0]/ics.evtoau, 0, ics.spectrum[state + 1]/np.max(ics.spectrum[-1]), color=colors[state], alpha=0.2)
+            axs.plot(
+                ics.spectrum[0] / ics.evtoau,
+                ics.spectrum[state + 1] / np.max(ics.spectrum[-1]),
+                color=colors[state],
+                linestyle="--",
+            )
+            axs.fill_between(
+                ics.spectrum[0] / ics.evtoau,
+                0,
+                ics.spectrum[state + 1] / np.max(ics.spectrum[-1]),
+                color=colors[state],
+                alpha=0.2,
+            )
             # weights of initial conditions plotted as sticks with points
-            axs.scatter(ics.de[state, :]/ics.evtoau, ics.weights[state, :]/maxw, color=colors[state], s=5)
+            axs.scatter(ics.de[state, :] / ics.evtoau, ics.weights[state, :] / maxw, color=colors[state], s=5)
             for index in range(ics.nsamples):
-                axs.plot([ics.de[state, index]/ics.evtoau]*2, [0, ics.weights[state, index]/maxw], color=colors[state])
+                axs.plot([ics.de[state, index] / ics.evtoau] * 2, [0, ics.weights[state, index] / maxw], color=colors[state])
 
-    axs.plot(ics.field_ft_omega/ics.evtoau, ics.field_ft**2, color='black', alpha=0.5, label='Pulse intensity spectrum')
-    axs.set_xlim(np.min(ics.spectrum[0]/ics.evtoau), np.max(ics.spectrum[0]/ics.evtoau))
+    axs.plot(ics.field_ft_omega / ics.evtoau, ics.field_ft**2, color="black", alpha=0.5, label="Pulse intensity spectrum")
+    axs.set_xlim(np.min(ics.spectrum[0] / ics.evtoau), np.max(ics.spectrum[0] / ics.evtoau))
     axs.set_ylim(0, 1.3)
     axs.set_xlabel(r"$E$ (eV)")
     axs.set_ylabel(r"$\epsilon$")
     axs.set_title(r"Pulse spectrum")
-    axs.legend(frameon=False, labelspacing=0.1, loc='upper left')
+    axs.legend(frameon=False, labelspacing=0.1, loc="upper left")
     axs.minorticks_on()
-    axs.tick_params('both', direction='in', which='both', top=True, right=True)
+    axs.tick_params("both", direction="in", which="both", top=True, right=True)
 
     plt.tight_layout()
-    plt.savefig('pdaw', dpi=300)
+    plt.savefig("pdaw", dpi=300)
     plt.show()
 
 
 def parse_cmd_args():
     ### setting up parser ###
     parser = argparse.ArgumentParser(description=DESC, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("-m", "--method", default='pda', choices=METHODS,
-                        help="Select either Promoted density approach (PDA) to generate initial conditions with excitation times or "
-                             "PDA for windowing (PDAW) to generate weights and convolution parameters.")
-    parser.add_argument("-np", "--npsamples", default=1000, type=positive_int, help="Number of initial conditions generated with PDA.")
+    parser.add_argument(
+        "-m",
+        "--method",
+        default="pda",
+        choices=METHODS,
+        help="Select either Promoted density approach (PDA) to generate initial conditions with excitation times or "
+        "PDA for windowing (PDAW) to generate weights and convolution parameters.",
+    )
+    parser.add_argument(
+        "-np", "--npsamples", default=1000, type=positive_int, help="Number of initial conditions generated with PDA."
+    )
 
     inp_file = parser.add_argument_group("Input file handling")
-    inp_file.add_argument("-n", "--nsamples", default=0, type=positive_int,
-                          help="Number of data points from the input file considered. By default all initial conditions provided in the input file are taken.")
+    inp_file.add_argument(
+        "-n",
+        "--nsamples",
+        default=0,
+        type=positive_int,
+        help="Number of data points from the input file considered. By default all initial conditions provided in the input file are taken.",
+    )
     inp_file.add_argument("-ns", "--nstates", default=1, type=positive_int, help="Number of excited states considered.")
-    inp_file.add_argument("-eu", "--energy_unit", choices=ENERGY_UNITS, default='a.u.', help="Units in which excitation energies are provided.")
-    inp_file.add_argument("-tu", "--tdm_unit", choices=TDM_UNITS, default='a.u.',
-                          help="Units in which magnitudes of transition dipole moments (|mu_ij|) are provided.")
-    inp_file.add_argument("-ft", "--file_type", choices=FILE_TYPES, default='file', help="Input file type.")
+    inp_file.add_argument(
+        "-eu", "--energy_unit", choices=ENERGY_UNITS, default="a.u.", help="Units in which excitation energies are provided."
+    )
+    inp_file.add_argument(
+        "-tu",
+        "--tdm_unit",
+        choices=TDM_UNITS,
+        default="a.u.",
+        help="Units in which magnitudes of transition dipole moments (|mu_ij|) are provided.",
+    )
+    inp_file.add_argument("-ft", "--file_type", choices=FILE_TYPES, default="file", help="Input file type.")
 
-    field = parser.add_argument_group('Field parameters')
+    field = parser.add_argument_group("Field parameters")
     field.add_argument("-w", "--omega", required=True, type=positive_float, help="Frequency of the field in a.u.")
-    field.add_argument("-f", "--fwhm", required=True, type=positive_float,
-                       help="Full Width at Half Maximum (FWHM) parameter for the pulse intensity envelope in fs.")
-    field.add_argument("-env", "--envelope_type", choices=ENVELOPE_TYPES, default='gauss', help="Field envelope type.")
-    field.add_argument("-lch", "--linear_chirp", default=0.0, type=float, help="Linear chirp [w(t) = w+lch*t] of the field frequency in a.u.")
+    field.add_argument(
+        "-f",
+        "--fwhm",
+        required=True,
+        type=positive_float,
+        help="Full Width at Half Maximum (FWHM) parameter for the pulse intensity envelope in fs.",
+    )
+    field.add_argument("-env", "--envelope_type", choices=ENVELOPE_TYPES, default="gauss", help="Field envelope type.")
+    field.add_argument(
+        "-lch", "--linear_chirp", default=0.0, type=float, help="Linear chirp [w(t) = w+lch*t] of the field frequency in a.u."
+    )
     field.add_argument("-t0", "--t0", default=0.0, type=float, help="Time of the field maximum in fs.")
 
-    parser.add_argument("-neg", "--neg_handling", choices=NEG_PROB_HANDLING, default='error', help="Procedures how to handle negative probabilities.")
-    parser.add_argument("-s", "--random_seed", default=None, type=positive_int,
-                        help="Seed for the random number generator. Default: generate random seed from OS.")
-    parser.add_argument("-ps", "--preselect", action="store_true",
-                        help="Preselect samples within pulse spectrum for PDA. This option provides significant speed "
-                             "up if the pulse spectrum covers only small part of the absorption spectrum as it avoids expensive "
-                             "calculation of W for non-resonant cases. The lost of accuracy should be minimal, yet we still "
-                             "recommend to use this option only if the calculation is too expensive, e.g. for very long pulses.")
-    parser.add_argument("-p", "--plot", action="store_true", help="Plot the input data and calculated results and save them as png images.")
+    parser.add_argument(
+        "-neg",
+        "--neg_handling",
+        choices=NEG_PROB_HANDLING,
+        default="error",
+        help="Procedures how to handle negative probabilities.",
+    )
+    parser.add_argument(
+        "-s",
+        "--random_seed",
+        default=None,
+        type=positive_int,
+        help="Seed for the random number generator. Default: generate random seed from OS.",
+    )
+    parser.add_argument(
+        "-ps",
+        "--preselect",
+        action="store_true",
+        help="Preselect samples within pulse spectrum for PDA. This option provides significant speed "
+        "up if the pulse spectrum covers only small part of the absorption spectrum as it avoids expensive "
+        "calculation of W for non-resonant cases. The lost of accuracy should be minimal, yet we still "
+        "recommend to use this option only if the calculation is too expensive, e.g. for very long pulses.",
+    )
+    parser.add_argument(
+        "-p", "--plot", action="store_true", help="Plot the input data and calculated results and save them as png images."
+    )
     parser.add_argument("input_file", help="Input file name.")
 
     return parser.parse_args()
@@ -815,10 +960,10 @@ def main():
     print_header()
     print("* Input parameters:")
     for key, value in vars(config).items():
-        add = ''
-        if key == 'nsamples' and value == 0:
-            add = '(All input data will be used)'
-        if config.method == 'pdaw' and key in ('npsamples', 'random_seed', 'preselect', 'neg_handling'):
+        add = ""
+        if key == "nsamples" and value == 0:
+            add = "(All input data will be used)"
+        if config.method == "pdaw" and key in ("npsamples", "random_seed", "preselect", "neg_handling"):
             continue
         print(f"  - {key:20s}: {value}   {add}")
 
@@ -828,8 +973,13 @@ def main():
 
     # convert pulse input to atomic units
     fstoau = 41.341374575751
-    pulse = LaserPulse(omega=config.omega, fwhm=config.fwhm*fstoau, envelope_type=config.envelope_type, lchirp=config.linear_chirp,
-                       t0=config.t0*fstoau, )
+    pulse = LaserPulse(
+        omega=config.omega,
+        fwhm=config.fwhm * fstoau,
+        envelope_type=config.envelope_type,
+        lchirp=config.linear_chirp,
+        t0=config.t0 * fstoau,
+    )
     print(f"* {pulse}")
 
     ics = InitialConditions(nsamples=config.nsamples, nstates=config.nstates, input_type=config.file_type)
@@ -848,13 +998,14 @@ def main():
         plot_field(ics)
 
     # perform either PDA or PDAW and plot
-    if config.method == 'pda':
-        ics.sample_initial_conditions(nsamples_ic=config.npsamples, neg_handling=config.neg_handling, preselect=config.preselect,
-                                      seed=config.random_seed)
+    if config.method == "pda":
+        ics.sample_initial_conditions(
+            nsamples_ic=config.npsamples, neg_handling=config.neg_handling, preselect=config.preselect, seed=config.random_seed
+        )
         if config.plot:
             plot_pda(ics)
 
-    elif config.method == 'pdaw':
+    elif config.method == "pdaw":
         ics.windowing()
         if config.plot:
             plot_pdaw(ics)
@@ -862,5 +1013,5 @@ def main():
     print_footer()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/supplementary/envelopes_analysis/field_envelopes.py
+++ b/supplementary/envelopes_analysis/field_envelopes.py
@@ -12,7 +12,7 @@ fwhm = 10  # in fs
 omega = 1  # in a.u.
 lchirp = 0  # in a.u.
 t0 = 0  # in fs
-envelope_types = ['sin', 'sin2', 'gauss', 'sech', 'lorentz']
+envelope_types = ["sin", "sin2", "gauss", "sech", "lorentz"]
 
 # conversion of units
 evtoau = 0.036749405469679
@@ -37,55 +37,55 @@ for i in range(len(envelope_types)):
     field.calc_field(pulse=pulse)
     field.field_ft_omega -= omega
 
-    axs[0, 0].plot(field.field_t/field.fstoau, field.field_envelope, color=colors[i], label=f"'{envelope_type}'")
-    axs[0, 1].plot(field.field_t/field.fstoau, field.field_envelope**2, color=colors[i], label=f"'{envelope_type}'")
-    axs[1, 0].plot(field.field_ft_omega/field.evtoau, field.field_ft, color=colors[i], label=f"'{envelope_type}'")
-    axs[1, 1].plot(field.field_ft_omega/field.evtoau, field.field_ft**2, color=colors[i], label=f"'{envelope_type}'")
+    axs[0, 0].plot(field.field_t / field.fstoau, field.field_envelope, color=colors[i], label=f"'{envelope_type}'")
+    axs[0, 1].plot(field.field_t / field.fstoau, field.field_envelope**2, color=colors[i], label=f"'{envelope_type}'")
+    axs[1, 0].plot(field.field_ft_omega / field.evtoau, field.field_ft, color=colors[i], label=f"'{envelope_type}'")
+    axs[1, 1].plot(field.field_ft_omega / field.evtoau, field.field_ft**2, color=colors[i], label=f"'{envelope_type}'")
 
-axs[0, 0].axhline(0.5, color='black', linestyle='--', lw=0.5)
-axs[0, 0].set_xlim(-3*fwhm/fstoau, 3*fwhm/fstoau)
+axs[0, 0].axhline(0.5, color="black", linestyle="--", lw=0.5)
+axs[0, 0].set_xlim(-3 * fwhm / fstoau, 3 * fwhm / fstoau)
 axs[0, 0].set_ylim(0, 1.2)
 axs[0, 0].set_xlabel(r"$t$ (fs)")
 axs[0, 0].set_ylabel(r"$\varepsilon(t)$")
 axs[0, 0].set_title(r"Pulse envelope")
-axs[0, 0].legend(frameon=False, labelspacing=0.1, loc='upper right')
+axs[0, 0].legend(frameon=False, labelspacing=0.1, loc="upper right")
 
-fwhm2 = fwhm/2/fstoau
-axs[0, 1].plot([-fwhm2, -fwhm2, fwhm2, fwhm2], [0, 0.5, 0.5, 0], color='black', linestyle='--')
-axs[0, 1].text(0, 0.2, r"$\tau_\mathregular{FWHM}$", horizontalalignment='center', color='black')
-axs[0, 1].set_xlim(-3*fwhm/fstoau, 3*fwhm/fstoau)
+fwhm2 = fwhm / 2 / fstoau
+axs[0, 1].plot([-fwhm2, -fwhm2, fwhm2, fwhm2], [0, 0.5, 0.5, 0], color="black", linestyle="--")
+axs[0, 1].text(0, 0.2, r"$\tau_\mathregular{FWHM}$", horizontalalignment="center", color="black")
+axs[0, 1].set_xlim(-3 * fwhm / fstoau, 3 * fwhm / fstoau)
 axs[0, 1].set_ylim(0, 1.2)
 axs[0, 1].set_xlabel(r"$t$ (fs)")
 axs[0, 1].set_ylabel(r"$I(t)$")
 axs[0, 1].set_title(r"Pulse intensity")
-axs[0, 1].legend(frameon=False, labelspacing=0.1, loc='upper right')
+axs[0, 1].legend(frameon=False, labelspacing=0.1, loc="upper right")
 
-axs[1, 0].set_xlim(-2*np.pi/fwhm*fstoau, 2*np.pi/fwhm*fstoau)
+axs[1, 0].set_xlim(-2 * np.pi / fwhm * fstoau, 2 * np.pi / fwhm * fstoau)
 axs[1, 0].set_ylim(0, 1.2)
 axs[1, 0].set_xlabel(r"$E$ (eV)")
 axs[1, 0].set_ylabel(r"$|\varepsilon(\omega)|$")
 axs[1, 0].set_title(r"Envelope spectrum")
-axs[1, 0].legend(frameon=False, labelspacing=0.1, loc='upper right')
+axs[1, 0].legend(frameon=False, labelspacing=0.1, loc="upper right")
 
-axs[1, 1].set_xlim(-2*np.pi/fwhm*fstoau, 2*np.pi/fwhm*fstoau)
+axs[1, 1].set_xlim(-2 * np.pi / fwhm * fstoau, 2 * np.pi / fwhm * fstoau)
 axs[1, 1].set_ylim(0, 1.2)
 axs[1, 1].set_xlabel(r"$E$ (eV)")
 axs[1, 1].set_ylabel(r"$S(\omega)$")
 axs[1, 1].set_title(r"Spectral intensity")
-axs[1, 1].legend(frameon=False, labelspacing=0.1, loc='upper right')
+axs[1, 1].legend(frameon=False, labelspacing=0.1, loc="upper right")
 
 plt.tight_layout()
-plt.savefig('implemented_envelopes', dpi=300)
+plt.savefig("implemented_envelopes", dpi=300)
 plt.show(block=False)
 
 # plotting Wigner transformations of the field
 print("\nWigner transfroms of the pulses")
-fig, axs = plt.subplots(2, len(envelope_types), figsize=(2.5*len(envelope_types), 5), sharex=True, sharey=True)
+fig, axs = plt.subplots(2, len(envelope_types), figsize=(2.5 * len(envelope_types), 5), sharex=True, sharey=True)
 
 # create a 2D map
 grid = 250
-e = np.linspace(-1.5*np.pi/fwhm*fstoau, 1.5*np.pi/fwhm*fstoau, grid)
-t = np.linspace(-2.1*fwhm/fstoau, 2.1*fwhm/fstoau, grid)
+e = np.linspace(-1.5 * np.pi / fwhm * fstoau, 1.5 * np.pi / fwhm * fstoau, grid)
+t = np.linspace(-2.1 * fwhm / fstoau, 2.1 * fwhm / fstoau, grid)
 e2d, t2d = np.meshgrid(e, t)
 
 for i in range(len(envelope_types)):
@@ -97,28 +97,30 @@ for i in range(len(envelope_types)):
 
     for j in range(len(t)):
         for k in range(len(e)):
-            pulse_wigner[j, k] = field.pulse_wigner(tprime=t2d[j, k]*fstoau, de=e2d[j, k]*evtoau + omega)
+            pulse_wigner[j, k] = field.pulse_wigner(tprime=t2d[j, k] * fstoau, de=e2d[j, k] * evtoau + omega)
 
     pulse_wigner /= np.max(np.abs(pulse_wigner))
-    pc = axs[0, i].pcolormesh(e2d, t2d, pulse_wigner, cmap='RdBu', vmin=-1, vmax=1)
-    if i == len(envelope_types) - 1: fig.colorbar(pc, ax=axs[0, i], shrink=0.92, fraction=0.05)
+    pc = axs[0, i].pcolormesh(e2d, t2d, pulse_wigner, cmap="RdBu", vmin=-1, vmax=1)
+    if i == len(envelope_types) - 1:
+        fig.colorbar(pc, ax=axs[0, i], shrink=0.92, fraction=0.05)
 
-    pc = axs[1, i].pcolormesh(e2d, t2d, pulse_wigner, cmap='Blues', norm='log', vmin=1e-5, vmax=1)
-    if i == len(envelope_types) - 1: fig.colorbar(pc, ax=axs[1, i], shrink=0.92, fraction=0.05)
-    pc = axs[1, i].pcolormesh(e2d, t2d, -pulse_wigner, cmap='Reds', norm='log', vmin=1e-5, vmax=1)
+    pc = axs[1, i].pcolormesh(e2d, t2d, pulse_wigner, cmap="Blues", norm="log", vmin=1e-5, vmax=1)
+    if i == len(envelope_types) - 1:
+        fig.colorbar(pc, ax=axs[1, i], shrink=0.92, fraction=0.05)
+    pc = axs[1, i].pcolormesh(e2d, t2d, -pulse_wigner, cmap="Reds", norm="log", vmin=1e-5, vmax=1)
 
     axs[1, i].set_xlabel(r"$\Delta E$ (eV)")
     axs[0, i].set_title(f"'{envelope_type}'")
-    axs[0, i].tick_params('both', direction='in', which='both', top=True, right=True)
-    axs[1, i].tick_params('both', direction='in', which='both', top=True, right=True)
+    axs[0, i].tick_params("both", direction="in", which="both", top=True, right=True)
+    axs[1, i].tick_params("both", direction="in", which="both", top=True, right=True)
 
 axs[0, 0].set_ylabel(r"$t$ (fs)")
 axs[1, 0].set_ylabel(r"$t$ (fs)")
 
-axs[0, 0].text(x=np.min(e) + 0.03, y=np.max(t) - 0.15*fwhm/fstoau, s=r"$\mathcal{W}_E(t,\Delta E)$", va="top", ha="left")
-axs[1, 0].text(x=np.min(e) + 0.03, y=np.max(t) - 0.15*fwhm/fstoau, s=r"$\ln[\mathcal{W}_E(t,\Delta E)]$", va="top", ha="left")
+axs[0, 0].text(x=np.min(e) + 0.03, y=np.max(t) - 0.15 * fwhm / fstoau, s=r"$\mathcal{W}_E(t,\Delta E)$", va="top", ha="left")
+axs[1, 0].text(x=np.min(e) + 0.03, y=np.max(t) - 0.15 * fwhm / fstoau, s=r"$\ln[\mathcal{W}_E(t,\Delta E)]$", va="top", ha="left")
 
 plt.tight_layout()
 fig.subplots_adjust(wspace=0, hspace=0)
-plt.savefig('envelope_wigner_transform', dpi=300)
+plt.savefig("envelope_wigner_transform", dpi=300)
 plt.show()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,9 @@ import pytest
 
 from promdens.promdens import LaserPulse
 
+
 @pytest.fixture
 def make_pulse():
-
     def _make_pulse(omega=0.1, fwhm=1.0, lchirp=0, t0=0, envelope_type="gauss"):
         return LaserPulse(omega=omega, fwhm=fwhm, lchirp=lchirp, t0=t0, envelope_type=envelope_type)
 

--- a/tests/test_methods_nai.py
+++ b/tests/test_methods_nai.py
@@ -13,21 +13,21 @@ path = Path(__file__).parent.absolute()
 
 
 def test_pdaw_nai(tmp_path):
-    ics = InitialConditions(nsamples=10, nstates=1, input_type='file')
+    ics = InitialConditions(nsamples=10, nstates=1, input_type="file")
 
-    ics.read_input_data(fname=path/'NaI_reference/test_data_nai.dat', energy_unit='a.u.', tdm_unit='a.u.')
+    ics.read_input_data(fname=path / "NaI_reference/test_data_nai.dat", energy_unit="a.u.", tdm_unit="a.u.")
 
     fstoau = 41.341374575751
-    pulse = LaserPulse(omega=0.13520905, fwhm=20*fstoau, envelope_type='gauss', lchirp=0, t0=0)
+    pulse = LaserPulse(omega=0.13520905, fwhm=20 * fstoau, envelope_type="gauss", lchirp=0, t0=0)
 
     ics.calc_field(pulse=pulse)
 
-    ics.windowing(output_fname=tmp_path/'pdaw.dat')
+    ics.windowing(output_fname=tmp_path / "pdaw.dat")
 
     # the following command was used to generate the reference
     # promdens -m pdaw -n 10 -w 0.13520905 -f 20 test_data_nai.dat
     # the reference was compared to exact QD
-    reference = np.genfromtxt(path/'NaI_reference/test_pdaw_reference.dat').T[1]
+    reference = np.genfromtxt(path / "NaI_reference/test_pdaw_reference.dat").T[1]
     weights = ics.weights[0]
 
     assert len(weights) == len(weights)
@@ -35,25 +35,29 @@ def test_pdaw_nai(tmp_path):
     for i in range(len(weights)):
         # the tolerance is the larger of the absolute and relative thresholds
         # equivalent to (weights[i] - reference[i]) < max([1e-18, reference[i]*1e-15])
-        assert weights[i] == pytest.approx(reference[i], abs=1e-18, rel=1e-15), f"pdaw weight[{i}] does not match: delta={weights[i] - reference[i]}"
+        assert weights[i] == pytest.approx(
+            reference[i], abs=1e-18, rel=1e-15
+        ), f"pdaw weight[{i}] does not match: delta={weights[i] - reference[i]}"
 
 
 def test_pda_nai(tmp_path):
-    ics = InitialConditions(nsamples=1000, nstates=1, input_type='file')
+    ics = InitialConditions(nsamples=1000, nstates=1, input_type="file")
 
-    ics.read_input_data(fname=path/'NaI_reference/test_data_nai.dat', energy_unit='a.u.', tdm_unit='a.u.')
+    ics.read_input_data(fname=path / "NaI_reference/test_data_nai.dat", energy_unit="a.u.", tdm_unit="a.u.")
 
     fstoau = 41.341374575751
-    pulse = LaserPulse(omega=0.14294844, fwhm=100*fstoau, envelope_type='gauss', lchirp=2e-6, t0=0)
+    pulse = LaserPulse(omega=0.14294844, fwhm=100 * fstoau, envelope_type="gauss", lchirp=2e-6, t0=0)
 
     ics.calc_field(pulse=pulse)
 
-    ics.sample_initial_conditions(nsamples_ic=10, neg_handling='error', preselect=True, seed=123456789, output_fname=tmp_path/'pda.dat')
+    ics.sample_initial_conditions(
+        nsamples_ic=10, neg_handling="error", preselect=True, seed=123456789, output_fname=tmp_path / "pda.dat"
+    )
 
     # the following command was used to generate the reference
     # promdens -np 10 -w 0.14294844 -lch 2e-6 -f 100 -ps --random_seed 123456789 -n 10 test_data_nai.dat
     # the reference was compared to exact QD
-    reference = np.genfromtxt(path/'NaI_reference/test_pda_reference.dat').T
+    reference = np.genfromtxt(path / "NaI_reference/test_pda_reference.dat").T
     pda = ics.ics
 
     assert len(pda) == len(reference)
@@ -64,4 +68,6 @@ def test_pda_nai(tmp_path):
         # comparing excitation times, the thresholds were based on numerical differences created by switching between numpy 1.26 and 2.1
         # the tolerance is the larger of the absolute and relative thresholds
         # equivalent to (pda[1, i] - reference[1, i]) < max([1e-18, reference[1, i]*1e-13])
-        assert pda[1, i] == pytest.approx(reference[1, i], abs=1e-18, rel=1e-13), f"pda excitation time for index {i} does not match: delta = {pda[1, i] - reference[1, i]}"
+        assert pda[1, i] == pytest.approx(
+            reference[1, i], abs=1e-18, rel=1e-13
+        ), f"pda excitation time for index {i} does not match: delta = {pda[1, i] - reference[1, i]}"

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -4,9 +4,10 @@ from inline_snapshot import snapshot
 
 from promdens.promdens import ENVELOPE_TYPES, InitialConditions, LaserPulse
 
+
 def test_invalid_envelope_type(make_pulse):
     with pytest.raises(ValueError):
-        make_pulse(envelope_type='invalid')
+        make_pulse(envelope_type="invalid")
 
 
 @pytest.mark.parametrize("envelope", ENVELOPE_TYPES)
@@ -20,7 +21,7 @@ def test_envelope_types(make_pulse, envelope):
 
 def test_field_cos(make_pulse):
     pulse = make_pulse(omega=0.1, lchirp=0.0)
-    t = np.array([-10., -1.0, 0.0, 1.0, 10.0])
+    t = np.array([-10.0, -1.0, 0.0, 1.0, 10.0])
     cos = pulse.field_cos(t)
 
     s = snapshot(


### PR DESCRIPTION
This PR proposes to use a ruff formatter for the code and enforce it in the CI. 
[Docs for ruff formatter](https://docs.astral.sh/ruff/formatter/)
[setup in PyCharm](https://docs.astral.sh/ruff/editors/setup/#pycharm)
One advantage of ruff is that it is also a linter (although I am not setting up the linter here, am planning to discuss separately in a follow-up PR), so we would have a single tool for both. 

Ruff uses a formatting style of another very common formatter called "black", and is quite different from what we have now.  @JanosJiri if you have a strong preference for the current format, that is totally fine, but in that case you need to figure out which formater PyCharm uses in your setup so I can use it as well and we can enforce it in CI.

Besides the choice of the formatter, there are other things to be decided:

- line length: Right now I have configured maximum line length to 130 to preserve existing format. I would personally preferred a bit shorter lines, but it is entirely up to you. @JanosJiri perhaps you can experiment locally with configuring shorter lines and see what looks best to you.
- Do we use single or double quotes? The current code was inconsistent so I used ruff's default of double quotes, but I have no strong opinions on this, both are fine and it is configurable. 