### PR TITLE
Decouple PyPI from TestPyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 env:
   FORCE_COLOR: 3
@@ -24,6 +25,9 @@ jobs:
     needs: [dist]
     name: Publish to TestPyPI
     if: github.repository == 'PHOTOX/promdens'
+    if: >-
+      github.repository == 'PHOTOX/promdens' &&
+      github.ref_type != 'tag'
     environment:
        name: testpypi
        url: https://test.pypi.org/p/promdens/
@@ -43,7 +47,7 @@ jobs:
 
   pypi-publish:
     name: Publish release to PyPI
-    needs: [test-publish]
+    needs: [dist]
     if: >-
       github.repository == 'PHOTOX/promdens' &&
       github.event_name == 'push' &&


### PR DESCRIPTION
This is a step towards a better release process. As we found out, we cannot publish to TestPyPI more than once for a given version. So here we change the workflow so that we run **either** the actual publish to PyPI **or** publish to TestPyPI. The former is triggered by creating a tag (which happens when making a release on Github) while the latter is currently triggered manually via workflow dispatch. I am going to try to improve the manual part in a separate PR.