### PR TITLE
Deduplicate version badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![PyPI version](https://img.shields.io/pypi/v/promdens)](https://pypi.org/project/promdens/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue)](/LICENSE)
 [![CI](https://github.com/PHOTOX/promdens/actions/workflows/ci.yml/badge.svg)](https://github.com/PHOTOX/promdens/actions/workflows/ci.yml)
 
 # PROMDENS: Promoted Density Approach code

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Version](https://img.shields.io/badge/Version-1.0.2-blue)](https://github.com/PHOTOX/promdens/releases)
 [![PyPI version](https://img.shields.io/pypi/v/promdens)](https://pypi.org/project/promdens/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue)](/LICENSE)
 [![CI](https://github.com/PHOTOX/promdens/actions/workflows/ci.yml/badge.svg)](https://github.com/PHOTOX/promdens/actions/workflows/ci.yml)


### PR DESCRIPTION
Probably makes sense to just keep the PyPI badge:

Also the MIT badge is redundant since GitHub now displays the license info right above it.

<img width="578" height="208" alt="image" src="https://github.com/user-attachments/assets/01d1b285-4038-4ccd-afd9-78da8686f0d7" />
