### PR TITLE
Trapezoid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.13"]
+        python: ["3.9", "3.13"]
 
     runs-on: ubuntu-22.04
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ After installation, the code is available as a script via the `promdens` command
 promdens --help
 ```
 
-The minimum supported Python version is 3.7.
+The minimum supported Python version is 3.9.
 The code depends on `numpy` and `matplotlib` libraries that are automatically installed by pip.
 However, since pip by default installs packages into a global Python environment,
 it can break previously installed packages, e.g., by installing an incompatible version of numpy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = [
 ]
 description = "Promoted Density Approach for sampling initial conditions for trajectory-based nonadiabatic photodynamics"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
-    "numpy>=1.15",
+    "numpy>=2.0.0",
     "matplotlib~=3.0",
 ]
 

--- a/src/promdens/promdens.py
+++ b/src/promdens/promdens.py
@@ -217,7 +217,7 @@ class LaserPulse:
             s = np.arange(0, factor[self.envelope_type]*self.fwhm, step=ds)
             # Note: We assume here that de is in atomic units, otherwise it needs to be divided by hbar
             cos = np.cos((de - loc_omega)*s)
-            integral = 2*np.trapz(x=s,
+            integral = 2*np.trapezoid(x=s,
                 y=cos*self.calc_field_envelope(tprime + s/2)*self.calc_field_envelope(tprime - s/2))
 
         return integral


### PR DESCRIPTION
np.trapz has been completely replaced by np.trapezoid in the latest version of numpy. Hence, we decided to support only np.trapezoid from now on. People insisting on using np.trapz can use older versions of promdens.